### PR TITLE
update `node12` to `node16`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -21,5 +21,5 @@ inputs:
     description: "Your Global Cloudflare API key. Highly not recommended to use"
     required: false
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
To mitigate https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.